### PR TITLE
added media-breakpoint-mixins

### DIFF
--- a/static/scss/atoms/media-breakpoint-mixins.scss
+++ b/static/scss/atoms/media-breakpoint-mixins.scss
@@ -1,0 +1,12 @@
+//media breakpoint mixins:
+@mixin sm-up {
+  @media (min-width: 768px) { @content; }
+}
+
+@mixin md-up {
+  @media (min-width: 992px) { @content; }
+}
+
+@mixin lg-up {
+  @media (min-width: 1200px) { @content; }
+}

--- a/static/scss/hip-styles.scss
+++ b/static/scss/hip-styles.scss
@@ -12,6 +12,7 @@
 
 // 3: Site-wide tags and basic styles
 @import "atoms/tags";
+@import "atoms/media-breakpoint-mixins";
 
 // 4: Widgets
 @import "widgets/inline_button";


### PR DESCRIPTION
Adding the media breakpoint mixin I adapted to straight bootstrap cutoffs from [The 100% correct way to do CSS breakpoints](https://medium.freecodecamp.org/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862) to easily add media queries within element styles.